### PR TITLE
Ensured that imports are removed when there is a match

### DIFF
--- a/.changeset/blue-geese-float.md
+++ b/.changeset/blue-geese-float.md
@@ -1,5 +1,5 @@
 ---
-"ember-codemod-add-template-tags": patch
+"ember-codemod-add-template-tags": minor
 ---
 
 Ensured that entityData.filePath doesn't refer to \*.hbs for components

--- a/.changeset/good-suns-enjoy.md
+++ b/.changeset/good-suns-enjoy.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-add-template-tags": minor
+---
+
+Ensured that imports are removed when there is a match

--- a/src/utils/update-template/remove-import.ts
+++ b/src/utils/update-template/remove-import.ts
@@ -90,11 +90,7 @@ export function removeImport(file: string, data: Data) {
 
   const ast = traverse(file, {
     visitImportDeclaration(node) {
-      if (
-        data.isTypeScript &&
-        data.importKind === 'value' &&
-        node.value.importKind === 'type'
-      ) {
+      if (data.importKind === 'value' && node.value.importKind === 'type') {
         return false;
       }
 
@@ -119,9 +115,8 @@ export function removeImport(file: string, data: Data) {
           let importKind = specifier.importKind;
 
           if (
-            data.isTypeScript &&
-            (node.value.importKind === 'type' ||
-              specifier.importKind === 'type')
+            node.value.importKind === 'type' ||
+            specifier.importKind === 'type'
           ) {
             importKind = 'type';
           }

--- a/src/utils/update-template/remove-import.ts
+++ b/src/utils/update-template/remove-import.ts
@@ -90,7 +90,11 @@ export function removeImport(file: string, data: Data) {
 
   const ast = traverse(file, {
     visitImportDeclaration(node) {
-      if (data.isTypeScript && node.value.importKind !== data.importKind) {
+      if (
+        data.isTypeScript &&
+        data.importKind === 'value' &&
+        node.value.importKind === 'type'
+      ) {
         return false;
       }
 
@@ -112,7 +116,22 @@ export function removeImport(file: string, data: Data) {
             return keepDefaultImport(specifier as SpecifierDefault);
           }
 
-          return keepNamedImport(specifier as SpecifierNamed, data);
+          let importKind = specifier.importKind;
+
+          if (
+            data.isTypeScript &&
+            (node.value.importKind === 'type' ||
+              specifier.importKind === 'type')
+          ) {
+            importKind = 'type';
+          }
+
+          const specifierModified: SpecifierNamed = {
+            ...(specifier as SpecifierNamed),
+            importKind,
+          };
+
+          return keepNamedImport(specifierModified, data);
         },
       );
 

--- a/tests/utils/update-template/remove-import/import-is-found-named-multiple-removals.test.ts
+++ b/tests/utils/update-template/remove-import/import-is-found-named-multiple-removals.test.ts
@@ -44,21 +44,10 @@ test('utils | update-template | remove-import > import is found (named, multiple
     isTypeScript: true,
   });
 
-  // TODO: Fix bug
-  // assert.strictEqual(
-  //   newFile,
-  //   [
-  //     `import { click, fillIn, render } from '@ember/test-helpers';`,
-  //     `import { hbs } from 'ember-cli-htmlbars';`,
-  //     `import { setupIntl } from 'ember-intl/test-support';`,
-  //     `import { setupRenderingTest } from 'my-app/tests/helpers';`,
-  //     `import { module, test } from 'qunit';`,
-  //   ].join('\n'),
-  // );
   assert.strictEqual(
     newFile,
     [
-      `import { click, fillIn, render, type TestContext as BaseTestContext } from '@ember/test-helpers';`,
+      `import { click, fillIn, render } from '@ember/test-helpers';`,
       `import { hbs } from 'ember-cli-htmlbars';`,
       `import { setupIntl } from 'ember-intl/test-support';`,
       `import { setupRenderingTest } from 'my-app/tests/helpers';`,

--- a/tests/utils/update-template/remove-import/import-kind-must-match-named.test.ts
+++ b/tests/utils/update-template/remove-import/import-kind-must-match-named.test.ts
@@ -13,9 +13,7 @@ test('utils | update-template | remove-import > importKind must match (named)', 
     isTypeScript: true,
   });
 
-  // TODO: Fix bug
-  // assert.strictEqual(newFile, '');
-  assert.strictEqual(newFile, `import type { hbs } from 'ember-cli-htmlbars';`);
+  assert.strictEqual(newFile, '');
 
   oldFile = `import { type hbs } from 'ember-cli-htmlbars';`;
 
@@ -27,9 +25,7 @@ test('utils | update-template | remove-import > importKind must match (named)', 
     isTypeScript: true,
   });
 
-  // TODO: Fix bug
-  // assert.strictEqual(newFile, '');
-  assert.strictEqual(newFile, `import { type hbs } from 'ember-cli-htmlbars';`);
+  assert.strictEqual(newFile, '');
 
   oldFile = `import type { hbs } from 'ember-cli-htmlbars';`;
 


### PR DESCRIPTION
## Background

Fixed a bug found via tests in #41.
