### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/bold-planes-fall.md
+++ b/.changeset/bold-planes-fall.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-add-template-tags": minor
+---
+
+Fixed lint errors

--- a/src/utils/find-entities/analyze-dependencies/analyze-barrel-file.ts
+++ b/src/utils/find-entities/analyze-dependencies/analyze-barrel-file.ts
@@ -31,21 +31,22 @@ function analyze(file: string, data: Data): EntitiesExported | undefined {
   };
 
   traverse(file, {
-    visitExportNamedDeclaration(node) {
+    visitExportNamedDeclaration(path) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (data.isTypeScript && node.value.exportKind !== 'value') {
+      if (data.isTypeScript && path.value.exportKind !== 'value') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const sourceType = node.value.source?.type as string | undefined;
+      const { source } = path.node;
 
-      if (sourceType !== 'Literal' && sourceType !== 'StringLiteral') {
+      if (
+        source?.type === undefined ||
+        (source.type !== 'Literal' && source.type !== 'StringLiteral')
+      ) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const exportPath = node.value.source.value as string;
+      const exportPath = source.value as string;
 
       for (const [entityType, entityFolder] of Object.entries(ENTITY_FOLDERS)) {
         if (!exportPath.startsWith(`./${entityFolder}/`)) {

--- a/src/utils/find-entities/analyze-dependencies/analyze-barrel-file.ts
+++ b/src/utils/find-entities/analyze-dependencies/analyze-barrel-file.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { readFileSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 
@@ -33,16 +32,19 @@ function analyze(file: string, data: Data): EntitiesExported | undefined {
 
   traverse(file, {
     visitExportNamedDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (data.isTypeScript && node.value.exportKind !== 'value') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const sourceType = node.value.source?.type as string | undefined;
 
       if (sourceType !== 'Literal' && sourceType !== 'StringLiteral') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const exportPath = node.value.source.value as string;
 
       for (const [entityType, entityFolder] of Object.entries(ENTITY_FOLDERS)) {

--- a/src/utils/find-packages-with-hbs/analyze-component.ts
+++ b/src/utils/find-packages-with-hbs/analyze-component.ts
@@ -42,26 +42,23 @@ export function analyzeComponent(file: string): Component {
   let hasDefaultExport = false;
 
   traverse(file, {
-    visitExportDefaultDeclaration(node) {
+    visitExportDefaultDeclaration(path) {
       hasDefaultExport = true;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      switch (node.value.declaration.type) {
+      switch (path.node.declaration.type) {
         case 'AssignmentExpression': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          componentName = node.value.declaration.left.name as string;
+          // @ts-expect-error: Incorrect type
+          componentName = path.node.declaration.left.name as string;
           break;
         }
 
         case 'ClassDeclaration': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          componentName = node.value.declaration.id?.name as string | undefined;
+          componentName = path.node.declaration.id?.name as string | undefined;
           break;
         }
 
         case 'Identifier': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          componentName = node.value.declaration.name as string;
+          componentName = path.node.declaration.name;
           break;
         }
       }
@@ -79,35 +76,30 @@ export function analyzeComponent(file: string): Component {
   }
 
   traverse(file, {
-    visitClassDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if ((node.value.id?.name as string | undefined) !== componentName) {
+    visitClassDeclaration(path) {
+      if ((path.node.id?.name as string | undefined) !== componentName) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (node.value.superClass?.type !== 'Identifier') {
+      if (path.node.superClass?.type !== 'Identifier') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      baseComponentName = node.value.superClass.name as string;
+      baseComponentName = path.node.superClass.name;
 
       return false;
     },
   });
 
   traverse(file, {
-    visitImportDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (node.value.importKind !== 'value') {
+    visitImportDeclaration(path) {
+      if (path.node.importKind !== 'value') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const importPath = node.value.source.value as string;
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const importSpecifiers = (node.value.specifiers ??
+      const importPath = path.node.source.value as string;
+
+      const importSpecifiers = (path.node.specifiers ??
         []) as ImportSpecifier[];
 
       switch (importPath) {

--- a/src/utils/find-packages-with-hbs/analyze-component.ts
+++ b/src/utils/find-packages-with-hbs/analyze-component.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 const componentMap = {
@@ -46,18 +45,22 @@ export function analyzeComponent(file: string): Component {
     visitExportDefaultDeclaration(node) {
       hasDefaultExport = true;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (node.value.declaration.type) {
         case 'AssignmentExpression': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           componentName = node.value.declaration.left.name as string;
           break;
         }
 
         case 'ClassDeclaration': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           componentName = node.value.declaration.id?.name as string | undefined;
           break;
         }
 
         case 'Identifier': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           componentName = node.value.declaration.name as string;
           break;
         }
@@ -77,14 +80,17 @@ export function analyzeComponent(file: string): Component {
 
   traverse(file, {
     visitClassDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if ((node.value.id?.name as string | undefined) !== componentName) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (node.value.superClass?.type !== 'Identifier') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       baseComponentName = node.value.superClass.name as string;
 
       return false;
@@ -93,11 +99,14 @@ export function analyzeComponent(file: string): Component {
 
   traverse(file, {
     visitImportDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (node.value.importKind !== 'value') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const importPath = node.value.source.value as string;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const importSpecifiers = (node.value.specifiers ??
         []) as ImportSpecifier[];
 

--- a/src/utils/update-components/insert-template-tag.ts
+++ b/src/utils/update-components/insert-template-tag.ts
@@ -14,16 +14,15 @@ function insertToGlimmerComponent(file: string, data: Data): string {
   const traverse = AST.traverse(true);
 
   const ast = traverse(file, {
-    visitClassDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const className = node.value.id?.name as string | undefined;
+    visitClassDeclaration(path) {
+      const className = path.node.id?.name as string | undefined;
 
       if (className !== data.componentName) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-      node.value.body.body.push(`${EOL}<template></template>`);
+      // @ts-expect-error: Incorrect type
+      path.node.body.body.push(`${EOL}<template></template>`);
 
       return false;
     },
@@ -43,43 +42,45 @@ function insertToTemplateOnlyComponent(file: string, data: Data): string {
     ].join(EOL);
 
     traverse(file, {
-      visitVariableDeclaration(node) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        if (node.value.declarations.length !== 1) {
+      visitVariableDeclaration(path) {
+        if (path.node.declarations.length !== 1) {
           return;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const declaration = node.value.declarations[0];
+        const declaration = path.node.declarations[0]!;
+
+        if (declaration.type !== 'VariableDeclarator') {
+          return false;
+        }
 
         if (
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           declaration.id.type !== 'Identifier' ||
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           declaration.id.name !== data.componentName
         ) {
           return false;
         }
 
+        if (declaration.init?.type !== 'CallExpression') {
+          return false;
+        }
+
+        // @ts-expect-error: Incorrect type
+        const { typeParameters } = declaration.init;
+
         if (
+          typeParameters === undefined ||
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          declaration.init.typeParameters === undefined ||
+          typeParameters.type !== 'TSTypeParameterInstantiation' ||
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          declaration.init.typeParameters.type !==
-            'TSTypeParameterInstantiation' ||
+          typeParameters.params[0].type !== 'TSTypeReference' ||
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          declaration.init.typeParameters.params[0].type !==
-            'TSTypeReference' ||
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          declaration.init.typeParameters.params[0].typeName.type !==
-            'Identifier'
+          typeParameters.params[0].typeName.type !== 'Identifier'
         ) {
           return false;
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        const signatureName = declaration.init.typeParameters.params[0].typeName
-          .name as string;
+        const signatureName = typeParameters.params[0].typeName.name as string;
 
         template += ` satisfies TOC<${signatureName}>`;
 
@@ -89,34 +90,34 @@ function insertToTemplateOnlyComponent(file: string, data: Data): string {
   }
 
   const ast = traverse(file, {
-    visitCallExpression(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (node.value.callee.name !== data.baseComponentName) {
+    visitCallExpression(path) {
+      // @ts-expect-error: Incorrect type
+      if (path.node.callee.name !== data.baseComponentName) {
         return false;
       }
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      switch (node.parentPath.value.type) {
+      switch (path.parent.node.type) {
         case 'AssignmentExpression': {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          node.parentPath.value.right = template;
+          path.parent.node.right = template;
           break;
         }
 
         case 'ExportDefaultDeclaration': {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          if (node.parentPath.value.id === undefined) {
+          if (path.parent.node.id === undefined) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            node.parentPath.value.declaration = template;
+            path.parent.node.declaration = template;
           }
           break;
         }
 
         case 'VariableDeclarator': {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          if (node.parentPath.value.id.name === data.componentName) {
+          if (path.parent.node.id.name === data.componentName) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            node.parentPath.value.init = template;
+            path.parent.node.init = template;
           }
           break;
         }

--- a/src/utils/update-components/insert-template-tag.ts
+++ b/src/utils/update-components/insert-template-tag.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { EOL } from 'node:os';
 
 import { AST } from '@codemod-utils/ast-javascript';
@@ -16,13 +15,14 @@ function insertToGlimmerComponent(file: string, data: Data): string {
 
   const ast = traverse(file, {
     visitClassDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const className = node.value.id?.name as string | undefined;
 
       if (className !== data.componentName) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
       node.value.body.body.push(`${EOL}<template></template>`);
 
       return false;
@@ -44,32 +44,40 @@ function insertToTemplateOnlyComponent(file: string, data: Data): string {
 
     traverse(file, {
       visitVariableDeclaration(node) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (node.value.declarations.length !== 1) {
           return;
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
         const declaration = node.value.declarations[0];
 
         if (
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           declaration.id.type !== 'Identifier' ||
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           declaration.id.name !== data.componentName
         ) {
           return false;
         }
 
         if (
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           declaration.init.typeParameters === undefined ||
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           declaration.init.typeParameters.type !==
             'TSTypeParameterInstantiation' ||
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           declaration.init.typeParameters.params[0].type !==
             'TSTypeReference' ||
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           declaration.init.typeParameters.params[0].typeName.type !==
             'Identifier'
         ) {
           return false;
         }
 
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const signatureName = declaration.init.typeParameters.params[0].typeName
           .name as string;
 
@@ -82,25 +90,32 @@ function insertToTemplateOnlyComponent(file: string, data: Data): string {
 
   const ast = traverse(file, {
     visitCallExpression(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (node.value.callee.name !== data.baseComponentName) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (node.parentPath.value.type) {
         case 'AssignmentExpression': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           node.parentPath.value.right = template;
           break;
         }
 
         case 'ExportDefaultDeclaration': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (node.parentPath.value.id === undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             node.parentPath.value.declaration = template;
           }
           break;
         }
 
         case 'VariableDeclarator': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (node.parentPath.value.id.name === data.componentName) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             node.parentPath.value.init = template;
           }
           break;

--- a/src/utils/update-template/remove-import.ts
+++ b/src/utils/update-template/remove-import.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 type Data = {
@@ -90,22 +89,26 @@ export function removeImport(file: string, data: Data): string {
 
   const ast = traverse(file, {
     visitImportDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (data.importKind === 'value' && node.value.importKind === 'type') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const sourceType = node.value.source?.type as string | undefined;
 
       if (sourceType !== 'Literal' && sourceType !== 'StringLiteral') {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const importPath = node.value.source.value as string;
 
       if (importPath !== data.importPath) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       node.value.specifiers = (node.value.specifiers as Specifier[]).filter(
         (specifier) => {
           if (data.isDefaultImport) {
@@ -115,6 +118,7 @@ export function removeImport(file: string, data: Data): string {
           let importKind = specifier.importKind;
 
           if (
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             node.value.importKind === 'type' ||
             specifier.importKind === 'type'
           ) {
@@ -130,6 +134,7 @@ export function removeImport(file: string, data: Data): string {
         },
       );
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (node.value.specifiers.length === 0) {
         return null;
       }

--- a/src/utils/update-template/remove-import.ts
+++ b/src/utils/update-template/remove-import.ts
@@ -58,8 +58,6 @@ type SpecifierNamedTypeScript = {
 
 type SpecifierNamed = SpecifierNamedJavaScript | SpecifierNamedTypeScript;
 
-type Specifier = SpecifierDefault | SpecifierNamed;
-
 function keepDefaultImport(specifier: SpecifierDefault): boolean {
   const { local, type } = specifier;
 
@@ -88,38 +86,36 @@ export function removeImport(file: string, data: Data): string {
   const traverse = AST.traverse(data.isTypeScript);
 
   const ast = traverse(file, {
-    visitImportDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (data.importKind === 'value' && node.value.importKind === 'type') {
+    visitImportDeclaration(path) {
+      if (data.importKind === 'value' && path.node.importKind === 'type') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const sourceType = node.value.source?.type as string | undefined;
+      const sourceType = path.node.source?.type as string | undefined;
 
       if (sourceType !== 'Literal' && sourceType !== 'StringLiteral') {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const importPath = node.value.source.value as string;
+      const importPath = path.node.source.value as string;
 
       if (importPath !== data.importPath) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      node.value.specifiers = (node.value.specifiers as Specifier[]).filter(
+      path.node.specifiers = (path.node.specifiers ?? []).filter(
         (specifier) => {
           if (data.isDefaultImport) {
             return keepDefaultImport(specifier as SpecifierDefault);
           }
 
+          // @ts-expect-error: Incorrect type
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           let importKind = specifier.importKind;
 
           if (
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            node.value.importKind === 'type' ||
+            path.node.importKind === 'type' ||
+            // @ts-expect-error: Incorrect type
             specifier.importKind === 'type'
           ) {
             importKind = 'type';
@@ -127,6 +123,7 @@ export function removeImport(file: string, data: Data): string {
 
           const specifierModified: SpecifierNamed = {
             ...(specifier as SpecifierNamed),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
             importKind,
           };
 
@@ -134,8 +131,7 @@ export function removeImport(file: string, data: Data): string {
         },
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (node.value.specifiers.length === 0) {
+      if (path.node.specifiers.length === 0) {
         return null;
       }
 

--- a/src/utils/update-tests/insert-template-tag.ts
+++ b/src/utils/update-tests/insert-template-tag.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
 import { EOL } from 'node:os';
 
 import { AST as ASTJavaScript } from '@codemod-utils/ast-javascript';
@@ -69,7 +68,9 @@ export function insertTemplateTag(file: string, data: Data): string {
   const ast = traverse(file, {
     visitCallExpression(node) {
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.callee.type !== 'Identifier' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.callee.name !== 'render'
       ) {
         this.traverse(node);
@@ -77,29 +78,38 @@ export function insertTemplateTag(file: string, data: Data): string {
       }
 
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.arguments.length !== 1 &&
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.arguments.length !== 2
       ) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const nodeValue = node.value.arguments[0]!;
 
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue?.type !== 'TaggedTemplateExpression' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue.tag.type !== 'Identifier' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue.tag.name !== 'hbs'
       ) {
         return false;
       }
 
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue.quasi.type !== 'TemplateLiteral' ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue.quasi.quasis[0].type !== 'TemplateElement'
       ) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       let template = nodeValue.quasi.quasis[0].value.raw as string;
 
       if (!data.useLexicalThis) {
@@ -108,27 +118,34 @@ export function insertTemplateTag(file: string, data: Data): string {
         if (renamedThis) {
           template = code;
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           switch (node.parent.parent.parent.value.type) {
             case 'BlockStatement': {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               const body = node.parent.parent.parent.value.body as unknown[];
 
               const index = body.findIndex((element) => {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 return element === node.parent.parent.value;
               });
 
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               node.parent.parent.parent.value.body = updateBody(body, index);
 
               break;
             }
 
             case 'FunctionExpression': {
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               const body = node.parent.parent.parent.value.body
                 .body as unknown[];
 
               const index = body.findIndex((element) => {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 return element === node.parent.value;
               });
 
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               node.parent.parent.parent.value.body.body = updateBody(
                 body,
                 index,
@@ -140,14 +157,17 @@ export function insertTemplateTag(file: string, data: Data): string {
         }
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const indent = node.value.loc.indent as number;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       node.value.arguments[0] = [
         `<template>`,
         `  ${indentToLeft(template.trim(), indent)}`,
         `</template>`,
       ].join(EOL);
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       node.value.typeParameters = null;
 
       return false;

--- a/src/utils/update-tests/insert-template-tag.ts
+++ b/src/utils/update-tests/insert-template-tag.ts
@@ -66,51 +66,40 @@ export function insertTemplateTag(file: string, data: Data): string {
   const traverse = ASTJavaScript.traverse(data.isTypeScript);
 
   const ast = traverse(file, {
-    visitCallExpression(node) {
+    visitCallExpression(path) {
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.callee.type !== 'Identifier' ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.callee.name !== 'render'
+        path.node.callee.type !== 'Identifier' ||
+        path.node.callee.name !== 'render'
       ) {
-        this.traverse(node);
+        this.traverse(path);
         return false;
       }
 
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.arguments.length !== 1 &&
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.arguments.length !== 2
+        path.node.arguments.length !== 1 &&
+        path.node.arguments.length !== 2
       ) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const nodeValue = node.value.arguments[0]!;
+      const nodeValue = path.node.arguments[0]!;
 
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue?.type !== 'TaggedTemplateExpression' ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue.tag.type !== 'Identifier' ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue.tag.name !== 'hbs'
       ) {
         return false;
       }
 
       if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         nodeValue.quasi.type !== 'TemplateLiteral' ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        nodeValue.quasi.quasis[0].type !== 'TemplateElement'
+        nodeValue.quasi.quasis[0]?.type !== 'TemplateElement'
       ) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      let template = nodeValue.quasi.quasis[0].value.raw as string;
+      let template = nodeValue.quasi.quasis[0].value.raw;
 
       if (!data.useLexicalThis) {
         const { code, renamedThis } = renameThis(template);
@@ -118,38 +107,37 @@ export function insertTemplateTag(file: string, data: Data): string {
         if (renamedThis) {
           template = code;
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+          const testFunctionPath = path.parent.parent.parent;
+
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          switch (node.parent.parent.parent.value.type) {
+          switch (testFunctionPath.value.type) {
             case 'BlockStatement': {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              const body = node.parent.parent.parent.value.body as unknown[];
+              const body = testFunctionPath.value.body as unknown[];
 
               const index = body.findIndex((element) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                return element === node.parent.parent.value;
+                return element === path.parent.parent.value;
               });
 
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              node.parent.parent.parent.value.body = updateBody(body, index);
+              testFunctionPath.value.body = updateBody(body, index);
 
               break;
             }
 
             case 'FunctionExpression': {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              const body = node.parent.parent.parent.value.body
-                .body as unknown[];
+              const body = testFunctionPath.value.body.body as unknown[];
 
               const index = body.findIndex((element) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                return element === node.parent.value;
+                return element === path.parent.value;
               });
 
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              node.parent.parent.parent.value.body.body = updateBody(
-                body,
-                index,
-              );
+              testFunctionPath.value.body.body = updateBody(body, index);
 
               break;
             }
@@ -157,18 +145,18 @@ export function insertTemplateTag(file: string, data: Data): string {
         }
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const indent = node.value.loc.indent as number;
+      // @ts-expect-error: Incorrect type
+      const indent = path.node.loc!.indent as number;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      node.value.arguments[0] = [
+      // @ts-expect-error: Incorrect type
+      path.node.arguments[0] = [
         `<template>`,
         `  ${indentToLeft(template.trim(), indent)}`,
         `</template>`,
       ].join(EOL);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      node.value.typeParameters = null;
+      // @ts-expect-error: Incorrect type
+      path.node.typeParameters = null;
 
       return false;
     },


### PR DESCRIPTION
## Background

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
