### PR TITLE
Supported conditional modifiers

### DIFF
--- a/.changeset/loud-ties-wish.md
+++ b/.changeset/loud-ties-wish.md
@@ -1,0 +1,5 @@
+---
+"ember-codemod-add-template-tags": minor
+---
+
+Supported conditional modifiers

--- a/src/utils/update-template/update-invocations.ts
+++ b/src/utils/update-template/update-invocations.ts
@@ -71,39 +71,43 @@ function updateTemplate(
 
       const helperName = node.path.original;
 
-      if (helperName === 'component') {
-        if (
-          node.params.length !== 1 ||
-          node.params[0]!.type !== 'StringLiteral'
-        ) {
-          return;
+      switch (helperName) {
+        case 'component': {
+          if (
+            node.params.length !== 1 ||
+            node.params[0]!.type !== 'StringLiteral'
+          ) {
+            break;
+          }
+
+          const componentName = node.params[0]!.original;
+          const entityData = entities.components.get(componentName);
+
+          if (!entityData) {
+            break;
+          }
+
+          const newName = pascalize(componentName);
+
+          node.params[0] = AST.builders.path(newName);
+          importStatements.add(newName, entityData);
+
+          break;
         }
 
-        const componentName = node.params[0]!.original;
-        const entityData = entities.components.get(componentName);
+        default: {
+          const entityData = entities.helpers.get(helperName);
 
-        if (!entityData) {
-          return;
+          if (!entityData) {
+            break;
+          }
+
+          const newName = camelize(helperName);
+
+          node.path.original = newName;
+          importStatements.add(newName, entityData);
         }
-
-        const newName = pascalize(componentName);
-
-        node.params[0] = AST.builders.path(newName);
-        importStatements.add(newName, entityData);
-
-        return;
       }
-
-      const entityData = entities.helpers.get(helperName);
-
-      if (!entityData) {
-        return;
-      }
-
-      const newName = camelize(helperName);
-
-      node.path.original = newName;
-      importStatements.add(newName, entityData);
     },
 
     SubExpression(node) {
@@ -113,39 +117,43 @@ function updateTemplate(
 
       const helperName = node.path.original;
 
-      if (helperName === 'component') {
-        if (
-          node.params.length !== 1 ||
-          node.params[0]!.type !== 'StringLiteral'
-        ) {
-          return;
+      switch (helperName) {
+        case 'component': {
+          if (
+            node.params.length !== 1 ||
+            node.params[0]!.type !== 'StringLiteral'
+          ) {
+            break;
+          }
+
+          const componentName = node.params[0]!.original;
+          const entityData = entities.components.get(componentName);
+
+          if (!entityData) {
+            break;
+          }
+
+          const newName = pascalize(componentName);
+
+          node.params[0] = AST.builders.path(newName);
+          importStatements.add(newName, entityData);
+
+          break;
         }
 
-        const componentName = node.params[0]!.original;
-        const entityData = entities.components.get(componentName);
+        default: {
+          const entityData = entities.helpers.get(helperName);
 
-        if (!entityData) {
-          return;
+          if (!entityData) {
+            break;
+          }
+
+          const newName = camelize(helperName);
+
+          node.path.original = newName;
+          importStatements.add(newName, entityData);
         }
-
-        const newName = pascalize(componentName);
-
-        node.params[0] = AST.builders.path(newName);
-        importStatements.add(newName, entityData);
-
-        return;
       }
-
-      const entityData = entities.helpers.get(helperName);
-
-      if (!entityData) {
-        return;
-      }
-
-      const newName = camelize(helperName);
-
-      node.path.original = newName;
-      importStatements.add(newName, entityData);
     },
   });
 

--- a/src/utils/update-template/update-invocations.ts
+++ b/src/utils/update-template/update-invocations.ts
@@ -141,6 +141,29 @@ function updateTemplate(
           break;
         }
 
+        case 'modifier': {
+          if (
+            node.params.length < 1 ||
+            node.params[0]!.type !== 'StringLiteral'
+          ) {
+            break;
+          }
+
+          const modifierName = node.params[0]!.original;
+          const entityData = entities.modifiers.get(modifierName);
+
+          if (!entityData) {
+            break;
+          }
+
+          const newName = camelize(modifierName);
+
+          node.params[0] = AST.builders.path(newName);
+          importStatements.add(newName, entityData);
+
+          break;
+        }
+
         default: {
           const entityData = entities.helpers.get(helperName);
 

--- a/tests/fixtures/my-v1-app-nested/input/app/components/my-button/index.hbs
+++ b/tests/fixtures/my-v1-app-nested/input/app/components/my-button/index.hbs
@@ -1,0 +1,3 @@
+<button type="button" {{(if @name (modifier "log-name" @name))}}>
+  Some label
+</button>

--- a/tests/fixtures/my-v1-app-nested/input/app/components/my-button/index.ts
+++ b/tests/fixtures/my-v1-app-nested/input/app/components/my-button/index.ts
@@ -1,0 +1,9 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface MyButtonSignature {
+  Args: {
+    name?: string;
+  };
+}
+
+export default templateOnlyComponent<MyButtonSignature>();

--- a/tests/fixtures/my-v1-app-nested/input/app/modifiers/log-name.ts
+++ b/tests/fixtures/my-v1-app-nested/input/app/modifiers/log-name.ts
@@ -1,0 +1,16 @@
+import { modifier } from 'ember-modifier';
+
+interface LogNameSignature {
+  Args: {
+    Positional: [string];
+  };
+  Element: Element;
+}
+
+export default modifier<LogNameSignature>(
+  function logMessage(element, positional) {
+    const name = positional[0];
+
+    console.log('log-name: ' + name);
+  },
+);

--- a/tests/fixtures/my-v1-app-nested/output/app/components/my-button/index.gts
+++ b/tests/fixtures/my-v1-app-nested/output/app/components/my-button/index.gts
@@ -1,0 +1,11 @@
+import type { TOC } from '@ember/component/template-only';
+
+interface MyButtonSignature {
+  Args: {
+    name?: string;
+  };
+}
+
+<template><button type="button" {{(if @name (modifier "log-name" @name))}}>
+  Some label
+</button></template>

--- a/tests/fixtures/my-v1-app-nested/output/app/components/my-button/index.gts
+++ b/tests/fixtures/my-v1-app-nested/output/app/components/my-button/index.gts
@@ -1,3 +1,5 @@
+import logName from 'docs-app/modifiers/log-name';
+
 import type { TOC } from '@ember/component/template-only';
 
 interface MyButtonSignature {
@@ -6,6 +8,6 @@ interface MyButtonSignature {
   };
 }
 
-<template><button type="button" {{(if @name (modifier "log-name" @name))}}>
+<template><button type="button" {{(if @name (modifier logName @name))}}>
   Some label
 </button></template>

--- a/tests/fixtures/my-v1-app-nested/output/app/modifiers/log-name.ts
+++ b/tests/fixtures/my-v1-app-nested/output/app/modifiers/log-name.ts
@@ -1,0 +1,16 @@
+import { modifier } from 'ember-modifier';
+
+interface LogNameSignature {
+  Args: {
+    Positional: [string];
+  };
+  Element: Element;
+}
+
+export default modifier<LogNameSignature>(
+  function logMessage(element, positional) {
+    const name = positional[0];
+
+    console.log('log-name: ' + name);
+  },
+);

--- a/tests/fixtures/my-v1-app/input/app/components/my-button.hbs
+++ b/tests/fixtures/my-v1-app/input/app/components/my-button.hbs
@@ -1,0 +1,3 @@
+<button type="button" {{(if @name (modifier "log-name" @name))}}>
+  Some label
+</button>

--- a/tests/fixtures/my-v1-app/input/app/components/my-button.ts
+++ b/tests/fixtures/my-v1-app/input/app/components/my-button.ts
@@ -1,0 +1,9 @@
+import templateOnlyComponent from '@ember/component/template-only';
+
+interface MyButtonSignature {
+  Args: {
+    name?: string;
+  };
+}
+
+export default templateOnlyComponent<MyButtonSignature>();

--- a/tests/fixtures/my-v1-app/input/app/modifiers/log-name.ts
+++ b/tests/fixtures/my-v1-app/input/app/modifiers/log-name.ts
@@ -1,0 +1,16 @@
+import { modifier } from 'ember-modifier';
+
+interface LogNameSignature {
+  Args: {
+    Positional: [string];
+  };
+  Element: Element;
+}
+
+export default modifier<LogNameSignature>(
+  function logMessage(element, positional) {
+    const name = positional[0];
+
+    console.log('log-name: ' + name);
+  },
+);

--- a/tests/fixtures/my-v1-app/output/app/components/my-button.gts
+++ b/tests/fixtures/my-v1-app/output/app/components/my-button.gts
@@ -1,0 +1,11 @@
+import type { TOC } from '@ember/component/template-only';
+
+interface MyButtonSignature {
+  Args: {
+    name?: string;
+  };
+}
+
+<template><button type="button" {{(if @name (modifier "log-name" @name))}}>
+  Some label
+</button></template>

--- a/tests/fixtures/my-v1-app/output/app/components/my-button.gts
+++ b/tests/fixtures/my-v1-app/output/app/components/my-button.gts
@@ -1,3 +1,5 @@
+import logName from 'docs-app/modifiers/log-name';
+
 import type { TOC } from '@ember/component/template-only';
 
 interface MyButtonSignature {
@@ -6,6 +8,6 @@ interface MyButtonSignature {
   };
 }
 
-<template><button type="button" {{(if @name (modifier "log-name" @name))}}>
+<template><button type="button" {{(if @name (modifier logName @name))}}>
   Some label
 </button></template>

--- a/tests/fixtures/my-v1-app/output/app/modifiers/log-name.ts
+++ b/tests/fixtures/my-v1-app/output/app/modifiers/log-name.ts
@@ -1,0 +1,16 @@
+import { modifier } from 'ember-modifier';
+
+interface LogNameSignature {
+  Args: {
+    Positional: [string];
+  };
+  Element: Element;
+}
+
+export default modifier<LogNameSignature>(
+  function logMessage(element, positional) {
+    const name = positional[0];
+
+    console.log('log-name: ' + name);
+  },
+);


### PR DESCRIPTION
## Background

[Since 3.27, Ember supported conditional modifiers](https://v5.chriskrycho.com/journal/conditional-modifiers-and-helpers-in-emberjs/) in `*.hbs` files. We would use the `modifier` keyword (built-in) and `()` to invoke an `if` or `unless` expression immediately.

Before:

```hbs
<button type="button" {{(if @name (modifier "log-name" @name))}}>
  Some label
</button>
```

After:

```gts
import logName from 'my-app/modifiers/log-name';

<template>
  <button type="button" {{(if @name (modifier logName @name))}}>
    Some label
  </button>
</template>
```


## References

- https://discord.com/channels/480462759797063690/483601670685720591/1501267370382196919